### PR TITLE
Mac OS X support for compilation

### DIFF
--- a/src/bcrypt.cc
+++ b/src/bcrypt.cc
@@ -52,7 +52,10 @@
 #include <pwd.h>
 
 #include "node_blf.h"
+
+#if !defined(__APPLE__) && !defined(__MACH__)
 #include "bsd/random.h"
+#endif
 
 /* This implementation is adaptable to current computing power.
  * You can have up to 2^31 rounds which should be enough for some

--- a/wscript
+++ b/wscript
@@ -1,4 +1,4 @@
-import Options, Utils
+import Options, Utils, sys
 from os import unlink, symlink, popen
 from os.path import exists, islink
 
@@ -15,7 +15,7 @@ def configure(conf):
   conf.check_tool("compiler_cc")
   conf.check_tool("node_addon")
 
-  if not conf.check(lib='bsd', libpath=['/usr/lib'], uselib_store='LIBBSD'):
+  if sys.platform != 'darwin' and not conf.check(lib='bsd', libpath=['/usr/lib'], uselib_store='LIBBSD'):
     conf.fatal("Cannot find bsd libraries (used for arc4random).")
 
 def build(bld):
@@ -26,10 +26,13 @@ def build(bld):
     src/bcrypt.cc
     src/bcrypt_node.cc
   """
-  bcryptnode.includes = """
-    /usr/includes/bsd/
-  """
-  bcryptnode.uselib = 'LIBBSD'
+
+  if sys.platform != 'darwin':
+    bcryptnode.includes = """
+      /usr/includes/bsd/
+    """
+    bcryptnode.uselib = 'LIBBSD'
+
 def test(t):
   Utils.exec_command('nodeunit test')
 


### PR DESCRIPTION
On Mac OS X (at least 10.6.4+), there's no need for libbsd for arc4random. I've basically added an exception in wscript and in bcrypt.cc to avoid the dependency and include for random.h on OS X, which makes it compile successfully.
