### PR TITLE
Fixed async call not validating salt

### DIFF
--- a/src/bcrypt_node.cc
+++ b/src/bcrypt_node.cc
@@ -91,10 +91,11 @@ bool ValidateSalt(char *str) {
     bool valid = true;
 
     char *new_str = strdup(str);
-    char *result = strtok(new_str, "$");
+    char *next_tok = new_str;
+    char *result = strsep(&next_tok, "$");
 
     while (result != NULL) {
-        if (count == 0) {
+        if (count == 1) {
             //check version
             if (!isdigit(result[0])) {
                 return false;
@@ -102,7 +103,7 @@ bool ValidateSalt(char *str) {
             if (strlen(result) == 2 && !isalpha(result[1])) {
                 return false;
             }
-        } else if (count == 1) {
+        } else if (count == 2) {
             //check rounds
             if (!(isdigit(result[0]) && isdigit(result[1]))) {
                 return false;
@@ -110,13 +111,13 @@ bool ValidateSalt(char *str) {
         }
 
         count++;
-        result = strtok(NULL, "$");
+        result = strsep(&next_tok, "$");
     }
 
     free(new_str);
     free(result);
 
-    return (count == 3);
+    return (count == 4);
 }
 
 /* SALT GENERATION */


### PR DESCRIPTION
Fixed async call not validating salt (use threadsafe strsep instead of strtok). This should fix your issue #20, and I've tested on a Mac OS X running 10,000 calls without any further errors.

Note that strsep is not POSIX-compliant and may not be present on all supported systems. On the other hand, the same thing goes for strdup, which is also in the code. It's your call.
