### PR TITLE
Lockfree, threadsafe implementation

### DIFF
--- a/src/node_blf.h
+++ b/src/node_blf.h
@@ -54,6 +54,7 @@
 #define BLF_MAXUTILIZED ((BLF_N+2)*4)	/* 576 bits */
 
 #define _PASSWORD_LEN   128             /* max length, not counting NUL */
+#define _SALT_LEN       32              /* max length */
 
 /* Blowfish context */
 typedef struct BlowfishContext {
@@ -90,8 +91,8 @@ void blf_cbc_decrypt(blf_ctx *, u_int8_t *, u_int8_t *, u_int32_t);
 u_int32_t Blowfish_stream2word(const u_int8_t *, u_int16_t , u_int16_t *);
 
 /* bcrypt functions*/
-char * bcrypt_gensalt(u_int8_t, u_int8_t*);
-char *bcrypt(const char *, const char *);
+void bcrypt_gensalt(u_int8_t, u_int8_t*, char *);
+void bcrypt(const char *, const char *, char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
 
 #endif


### PR DESCRIPTION
I've implemented a lockfree (faster?), threadsafe (hopefully?) version, and hopefully fixed your heisenbug crash too. The code passes all the current tests on a Snow Leopard system.
1. The cause of incorrect salts and encryption in async calls (e.g. in #20) seems to be non-threadsafe versions of bcrypt and bcrypt_gensalt in bcrypt.cc. In particular, they reference global variables encrypted and gsalt, so when used from multiple threads, they will stomp over each other's return values. I've added input result buffers to each function instead and had the callers preallocate these so that multiple threads end up with distinct results.
2. The maximum salt size had been set to BCRYPT_MAXSALT / 4 \* 3 + 1, but the generated salts actually have an extra 7 chars in front and the base64 encoding calculation rounds incorrectly (16 octets == 24 chars instead of 21 chars). The salt buffer had been a global and generating salt could sometimes result in a buffer overflow in global memory. So I've used a new constant _SALT_LEN to represent these 7 chars + 24 chars + 1 null termination.
3. Fix 1. and 2. passed the many_async test. I then removed all the mutexes, and the code still passed the many_async test.
