### PR TITLE
add a get_rounds function that can extract the number of rounds used from a hash. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ API
     * `cb` - [REQUIRED] - a callback to be fired once the data has been compared. uses eio making it asynchronous.
       * `err` - First parameter to the callback detailing any errors.
       * `same` - Second parameter to the callback providing whether the data and encrypted forms match [true | false].
+  * `get_rounds(encrypted)` - return the number of rounds used to encrypt a given hash
+    * `encrypted` - [REQUIRED] - hash from which the number of rounds used should be extracted.
+
 
 Hash Info
 ============

--- a/examples/async_compare.js
+++ b/examples/async_compare.js
@@ -7,6 +7,7 @@ bcrypt.gen_salt(10, function(err, salt) {
   bcrypt.encrypt('test', salt, function(err, crypted) {
     console.log('crypted: ' + crypted);
     console.log('crypted cb end: ' + (Date.now() - start) + 'ms');
+    console.log('rounds used from hash:', bcrypt.get_rounds(crypted));
     bcrypt.compare('test', crypted, function(err, res) {
       console.log('compared true: ' + res);
       console.log('compared true cb end: ' + (Date.now() - start) + 'ms');

--- a/src/bcrypt.cc
+++ b/src/bcrypt.cc
@@ -282,6 +282,19 @@ bcrypt(const char *key, const char *salt, char *encrypted)
 	memset(cdata, 0, sizeof(cdata));
 }
 
+u_int32_t bcrypt_get_rounds(const char * hash)
+{
+  /* skip past the leading "$" */
+  if (!hash || *(hash++) != '$') return 0;
+
+  /* skip past version */
+  if (0 == (*hash++)) return 0;
+  if (*hash && *hash != '$') hash++;
+  if (*hash++ != '$') return 0;
+
+  return  atoi(hash);
+}
+
 static void
 encode_base64(u_int8_t *buffer, u_int8_t *data, u_int16_t len)
 {

--- a/src/bcrypt_node.cc
+++ b/src/bcrypt_node.cc
@@ -506,6 +506,26 @@ Handle<Value> CompareSync(const Arguments& args) {
     return Boolean::New(CompareStrings(bcrypted, *hash));
 }
 
+Handle<Value> GetRounds(const Arguments& args) {
+    HandleScope scope;
+
+    if (args.Length() < 1) {
+        return ThrowException(Exception::Error(String::New("Must provide hash.")));
+    } else if (!args[0]->IsString()) {
+        return ThrowException(Exception::Error(String::New("Hash must be a string.")));
+    }
+
+    String::Utf8Value hash(args[0]->ToString());
+
+    u_int32_t rounds;
+
+    if (!(rounds = bcrypt_get_rounds(*hash))) {
+        return ThrowException(Exception::Error(String::New("invalid hash provided")));
+    }
+
+    return Integer::New(rounds);
+}
+
 } // anonymous namespace
 
 // bind the bcrypt module
@@ -515,6 +535,7 @@ extern "C" void init(Handle<Object> target) {
     NODE_SET_METHOD(target, "gen_salt_sync", GenerateSaltSync);
     NODE_SET_METHOD(target, "encrypt_sync", EncryptSync);
     NODE_SET_METHOD(target, "compare_sync", CompareSync);
+    NODE_SET_METHOD(target, "get_rounds", GetRounds);
     NODE_SET_METHOD(target, "gen_salt", GenerateSalt);
     NODE_SET_METHOD(target, "encrypt", Encrypt);
     NODE_SET_METHOD(target, "compare", Compare);

--- a/src/node_blf.h
+++ b/src/node_blf.h
@@ -94,5 +94,6 @@ u_int32_t Blowfish_stream2word(const u_int8_t *, u_int16_t , u_int16_t *);
 void bcrypt_gensalt(u_int8_t, u_int8_t*, char *);
 void bcrypt(const char *, const char *, char *);
 void encode_salt(char *, u_int8_t *, u_int16_t, u_int8_t);
+u_int32_t bcrypt_get_rounds(const char *);
 
 #endif

--- a/test/sync.js
+++ b/test/sync.js
@@ -71,5 +71,10 @@ module.exports = testCase({
         assert.ok(bcrypt.compare_sync("test", hash), "These hashes should be equal.");
         assert.ok(!(bcrypt.compare_sync("blah", hash)), "These hashes should not be equal.");
         assert.done();
+    },
+    test_get_rounds: function(assert) {
+        var hash = bcrypt.encrypt_sync("test", bcrypt.gen_salt_sync(9));
+        assert.equals(9, bcrypt.get_rounds(hash), "get_rounds can't extract rounds");
+        assert.done();
     }
 });


### PR DESCRIPTION
add a get_rounds that can extract the number of rounds used from a hash.  implementation is inside bcrypt.cc so that all code that understands hash format is in one place.

Yeah, this is kinda artificial cause you could just parse it out from javascript, but this the format of the hash string stays a private implementation detail.
