### PR TITLE
make `compile` task depend on `configure` task so they don't run in parallel and crash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build: clean configure compile
 configure:
 	node-waf configure
 
-compile:
+compile: configure
 	node-waf build
 
 test: build


### PR DESCRIPTION
Currently, if you run `make` in parallel (either with the `-j` flag or if you have `MAKEFLAGS` in your environment), then running `make build` fails because it tries to run `node-waf compile` before `node-waf configure` is done.

The solution is to make the `compile` task depend on the `configure` task.
