### PR TITLE
Use OpenSSL-Win32

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,8 @@
 {
+  'variables': {
+    # The default install location of OpenSSL-Win32
+    'openssl_Root': 'C:/OpenSSL-Win32'
+  },
   'targets': [
     {
       'target_name': 'bcrypt_lib',
@@ -9,7 +13,22 @@
         'src/blowfish.cc',
         'src/bcrypt.cc',
         'src/bcrypt_node.cc'
-      ]
+      ],
+      'conditions': [
+        [ 'OS=="win"', {
+          'defines': [
+            'uint=unsigned int',
+            # we need to use node's preferred "win32" rather than gyp's preferred "win"
+            'PLATFORM="win32"',
+          ],
+          'libraries': [ 
+            '-l<(openssl_Root)/lib/libeay32.lib',
+          ],
+          'include_dirs': [
+            '<(openssl_Root)/include',
+          ],
+        }],
+      ],
     }
   ]
 }

--- a/src/bcrypt.cc
+++ b/src/bcrypt.cc
@@ -49,8 +49,11 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <string.h>
-#include <pwd.h>
 #include "node_blf.h"
+
+#ifdef _WIN32 
+#define snprintf _snprintf
+#endif
 
 //#if !defined(__APPLE__) && !defined(__MACH__)
 //#include "bsd/stdlib.h"

--- a/src/bcrypt_node.cc
+++ b/src/bcrypt_node.cc
@@ -69,9 +69,9 @@ static void crypto_lock_init(void) {
 
 static void crypto_lock_cb(int mode, int n, const char* file, int line) {
   if (mode & CRYPTO_LOCK)
-    WaitForSingleObject(locks[type], INFINITE);
+    WaitForSingleObject(locks[n], INFINITE);
   else
-    ReleaseMutex(locks[type]);
+    ReleaseMutex(locks[n]);
 }
 
 static unsigned long crypto_id_cb(void) {
@@ -475,3 +475,4 @@ extern "C" void init(Handle<Object> target) {
     NODE_SET_METHOD(target, "compare", Compare);
 };
 
+NODE_MODULE(bcrypt_lib, init);

--- a/src/node_blf.h
+++ b/src/node_blf.h
@@ -42,6 +42,13 @@
 #define u_int64_t uint64_t
 #endif
 
+#ifdef _WIN32 
+#define u_int8_t unsigned __int8
+#define u_int16_t unsigned __int16
+#define u_int32_t unsigned __int32
+#define u_int64_t unsigned __int64
+#endif
+
 #define BCRYPT_VERSION '2'
 #define BCRYPT_MAXSALT 16	/* Precomputation is just so nice */
 #define BCRYPT_BLOCKS 6		/* Ciphertext blocks */


### PR DESCRIPTION
Then OpenSSL website [suggests](http://www.openssl.org/related/binaries.html) that the library be downloaded for Windows from http://slproweb.com/products/Win32OpenSSL.html. This should probably be the recommended method for all Windows users.

This expects that to have been downloaded, and installed in the default location, `C:\OpenSSL-Win32`.
