### PR TITLE
Updated readme.md to reflect requirements for 64bit windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Dependencies
 =============
 
 * NodeJS
-* Python 2.x
 * OpenSSL (Development Libraries (header files) for compilation)
  * For Windows you'll need http://slproweb.com/products/Win32OpenSSL.html installed to the default location of `C:\OpenSSL-Win32`
   * Please note that for this to build properly you'll need the Normal version of OpenSSL-Win<arch>, not the Light version. The reason for this is that we need to be able to compile the code using the header files that exist in the Normal version.


### PR DESCRIPTION
Updated the readme.md file to reflect the need for 64 bit windows users to use bcrypt version 0.7.2 minimum to fix the error with missing opensslconf.h include
