### PR TITLE
Add note about OpenSSL DLL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Dependencies
 * NodeJS
 * OpenSSL (Development Libraries (header files) for compilation)
  * For Windows you'll need http://slproweb.com/products/Win32OpenSSL.html installed to the default location of `C:\OpenSSL-Win32`
+  * When installing OpenSSL, you must tell it to put DLLs in `The Windows system directory` to avoid `The specified module could not be found.` errors.
   * Please note that for this to build properly you'll need the Normal version of OpenSSL-Win<arch>, not the Light version. The reason for this is that we need to be able to compile the code using the header files that exist in the Normal version.
   * For 64 bit use the 64 bit version and install to `C:\OpenSSL-Win64`
 * `node-gyp`


### PR DESCRIPTION
This avoids the following error:

```
The specified module could not be found.
...\node_modules\bcrypt\build\Release\bcrypt_lib.node
```

Copying `libeay32.dll` to `node_modules\bcrypt\build\Release` would also help.
#143 and #114 may be caused by this issue
