### PR TITLE
Remove the seed_length argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,10 @@ var hash = bcrypt.hashSync('bacon', 8);
 
 `BCrypt.`
 
-  * `genSaltSync(rounds, seed_length)`
+  * `genSaltSync(rounds)`
     * `rounds` - [OPTIONAL] - the number of rounds to process the data for. (default - 10)
-    * `seed_length` - [OPTIONAL] - RAND_bytes wants a length. to make that a bit flexible, you can specify a seed_length. (default - 20)
-  * `genSalt(rounds, seed_length, cb)`
+  * `genSalt(rounds, cb)`
     * `rounds` - [OPTIONAL] - the number of rounds to process the data for. (default - 10)
-    * `seed_length` - [OPTIONAL] - RAND_bytes wants a length. to make that a bit flexible, you can specify a seed_length. (default - 20)
     * `cb` - [REQUIRED] - a callback to be fired once the salt has been generated. uses eio making it asynchronous.
       * `err` - First parameter to the callback detailing any errors.
       * `salt` - Second parameter to the callback providing the generated salt.

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -2,9 +2,8 @@ var bindings = require('bindings')('bcrypt_lib');
 
 /// generate a salt (sync)
 /// @param {Number} [rounds] number of rounds (default 10)
-/// @param {Number} [seed_length] number of random bytes (default 20)
 /// @return {String} salt
-module.exports.genSaltSync = function(rounds, seed_length) {
+module.exports.genSaltSync = function(rounds) {
     // default 10 rounds
     if (!rounds) {
         rounds = 10;
@@ -12,32 +11,22 @@ module.exports.genSaltSync = function(rounds, seed_length) {
         throw new Error('rounds must be a number');
     }
 
-    // default length 20
-    if (!seed_length) {
-        seed_length = 20;
-    } else if (typeof seed_length !== 'number') {
-        throw new Error('seed_length must be a number');
-    }
-
-    return bindings.gen_salt_sync(rounds, seed_length);
+    return bindings.gen_salt_sync(rounds);
 };
 
 /// generate a salt
 /// @param {Number} [rounds] number of rounds (default 10)
-/// @param {Number} [seed_length] number of random bytes (default 20)
 /// @param {Function} cb callback(err, salt)
-module.exports.genSalt = function(rounds, seed_length, cb) {
+module.exports.genSalt = function(rounds, ignore, cb) {
     // if callback is first argument, then use defaults for others
     if (typeof arguments[0] === 'function') {
         // have to set callback first otherwise arguments are overriden
         cb = arguments[0];
         rounds = 10;
-        seed_length = 20;
     // callback is second argument
     } else if (typeof arguments[1] === 'function') {
         // have to set callback first otherwise arguments are overriden
         cb = arguments[1];
-        seed_length = 20;
     }
 
     // default 10 rounds
@@ -47,18 +36,11 @@ module.exports.genSalt = function(rounds, seed_length, cb) {
         return cb(new Error('rounds must be a number'));
     }
 
-    // default length 20
-    if (!seed_length) {
-        seed_length = 20;
-    } else if (typeof seed_length !== 'number') {
-        return cb(new Error('seed_length must be a number'));
-    }
-
     if (!cb) {
         return;
     }
 
-    return bindings.gen_salt(rounds, seed_length, cb);
+    return bindings.gen_salt(rounds, cb);
 };
 
 /// hash data using a salt


### PR DESCRIPTION
[`bcrypt_gensalt` expects a seed of exactly BCRYPT_MAXSALT (16) bytes](https://github.com/ncb000gt/node.bcrypt.js/blob/906860691011c9b088a11561f848690265bbda8b/src/bcrypt.cc#L158); other values are not useful:
- seed_length < 16 results in an invalid read
- seed_length > 16 (e.g. the default of 20) generates extra random bytes and then discards them

In general, I don't see a clear use case for user-specified seed length. Neither the [ruby](https://github.com/codahale/bcrypt-ruby/blob/f167f92c702ea6b01a9995e3089f49b95c34eecb/lib/bcrypt/engine.rb#L72) nor [python](https://code.google.com/p/py-bcrypt/source/browse/bcrypt/__init__.py#54) implementations allow this.

For backward compatibility, I have not removed support for a three-argument call to `genSalt`; the former `seed_length` parameter is simply ignored. If you want to remove the ignored argument and increment to version 0.8.0 I'm fine with that too.

I'm also curious why the library uses `RAND_bytes`/`RAND_pseudo_bytes`, thus requiring a direct OpenSSL dependency and the attendant locking incantations, rather than using `crypto.randomBytes`. If you are amenable, I will submit a pull request to change that and remove the OpenSSL dependency.
