### PR TITLE
Use crypto.randomBytes rather than using OpenSSL directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ To make it easier for people using this tool to analyze what has been surveyed, 
 ## Dependencies
 
 * NodeJS
-* OpenSSL (Development Libraries (header files) for compilation)
- * For Windows you'll need http://slproweb.com/products/Win32OpenSSL.html installed to the default location of `C:\OpenSSL-Win32`
-  * When installing OpenSSL, you must tell it to put DLLs in `The Windows system directory` to avoid `The specified module could not be found.` errors.
-  * Please note that for this to build properly you'll need the Normal version of OpenSSL-Win<arch>, not the Light version. The reason for this is that we need to be able to compile the code using the header files that exist in the Normal version.
-  * For 64 bit use the 64 bit version and install to `C:\OpenSSL-Win64`
 * `node-gyp`
  * Please check the dependencies for this tool at: https://github.com/TooTallNate/node-gyp/
   * Windows users will need the options for c# and c++ installed with their visual studio instance.

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -1,4 +1,5 @@
 var bindings = require('bindings')('bcrypt_lib');
+var crypto = require('crypto');
 
 /// generate a salt (sync)
 /// @param {Number} [rounds] number of rounds (default 10)
@@ -11,7 +12,7 @@ module.exports.genSaltSync = function(rounds) {
         throw new Error('rounds must be a number');
     }
 
-    return bindings.gen_salt_sync(rounds);
+    return bindings.gen_salt_sync(rounds, crypto.randomBytes(16));
 };
 
 /// generate a salt
@@ -40,7 +41,7 @@ module.exports.genSalt = function(rounds, ignore, cb) {
         return;
     }
 
-    return bindings.gen_salt(rounds, cb);
+    return bindings.gen_salt(rounds, crypto.randomBytes(16), cb);
 };
 
 /// hash data using a salt

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,31 +9,8 @@
       ],
       'conditions': [
         [ 'OS=="win"', {
-          'conditions': [
-            # "openssl_root" is the directory on Windows of the OpenSSL files
-            ['target_arch=="x64"', {
-              'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win64'
-              },
-            }, {
-              'variables': {
-                'openssl_root%': 'C:/OpenSSL-Win32'
-              },
-            }],
-          ],
           'defines': [
             'uint=unsigned int',
-          ],
-          'libraries': [ 
-            '-l<(openssl_root)/lib/libeay32.lib',
-          ],
-          'include_dirs': [
-            '<(openssl_root)/include',
-          ],
-        }, { # OS!="win"
-          'include_dirs': [
-            # use node's bundled openssl headers on Unix platforms
-            '<(node_root_dir)/deps/openssl/openssl/include'
           ],
         }],
       ],


### PR DESCRIPTION
This eliminates the direct OpenSSL dependency from node.bcrypt itself.

There's still some OpenSSL-related stuff in `wscript`, but I believe that file should simply be removed now that node-gyp is being used.
