### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ bcrypt.compare("B4c0/\/", hash, function(err, res) {
     // res == true
 });
 bcrypt.compare("not_bacon", hash, function(err, res) {
-    // res = false
+    // res == false
 });
 ```
 


### PR DESCRIPTION
This pull request only adds a '=' in comment lines so comments for true and false compares match. No other files have been modified.

BEFORE

```
bcrypt.compare("B4c0/\/", hash, function(err, res) {
    // res == true
});
bcrypt.compare("not_bacon", hash, function(err, res) {
    // res = false
});
```

AFTER

```
bcrypt.compare("B4c0/\/", hash, function(err, res) {
    // res == true
});
bcrypt.compare("not_bacon", hash, function(err, res) {
    // res == false
});
```
