### PR TITLE
fixed error logging problems in synchronous library calls

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -11,7 +11,7 @@ module.exports.genSaltSync = function(rounds) {
     if (!rounds) {
         rounds = 10;
     } else if (typeof rounds !== 'number') {
-        throw new Error('rounds must be a number');
+        return new Error('rounds must be a number');
     }
 
     return bindings.gen_salt_sync(rounds, crypto.randomBytes(16));
@@ -52,11 +52,11 @@ module.exports.genSalt = function(rounds, ignore, cb) {
 /// @return {String} hash
 module.exports.hashSync = function(data, salt) {
     if (data == null || salt == null) {
-        throw new Error('data and salt arguments required');
+        return new Error('data and salt arguments required');
     }
 
     if (typeof data !== 'string' || (typeof salt !== 'string' && typeof salt !== 'number')) {
-        throw new Error('data must be a string and salt must either be a salt string or a number of rounds');
+        return new Error('data must be a string and salt must either be a salt string or a number of rounds');
     }
 
     if (typeof salt === 'number') {
@@ -106,11 +106,11 @@ module.exports.hash = function(data, salt, cb) {
 /// @return {bool} true if hashed data matches hash
 module.exports.compareSync = function(data, hash) {
     if (data == null || hash == null) {
-        throw new Error('data and hash arguments required');
+        return new Error('data and hash arguments required');
     }
 
     if (typeof data !== 'string' || typeof hash !== 'string') {
-        throw new Error('data and hash must be strings');
+        return new Error('data and hash must be strings');
     }
 
     return bindings.compare_sync(data, hash);


### PR DESCRIPTION
Synchronous code should 'return' rather than 'throw' errors. This fixes logging problems in Express where error logging wasn't logging the error messages provided by bcrypt.
