### PR TITLE
add "node-gyp rebuild" install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/ncb000gt/node.bcrypt.js/issues"
   },
   "scripts": {
+    "install" : "(node-gyp rebuild 2> builderror.log) || (exit 0)", 
     "test": "node-gyp configure build && nodeunit test"
   },
   "dependencies": {


### PR DESCRIPTION
I believe this fixes https://github.com/ncb000gt/node.bcrypt.js/issues/193 , which is an issue we've lived with for some time (across many versions of our package.json).

Other modules we depend on that leverage node-gyp have an install script in their package.json with the following boilerplate:

`(node-gyp rebuild 2> builderror.log) || (exit 0)`
- https://github.com/mongodb/js-bson/blob/master/package.json#L25
- https://github.com/einaros/ws/blob/master/package.json#L24

The note on [npm package.json page](https://www.npmjs.org/doc/files/package.json.html) would seem to argue it isn't necessary, but experience tells me otherwise:

```
If there is a binding.gyp file in the root of your package, npm will default the preinstall command to compile using node-gyp.
```

This PR adds the boilerplate install script line, which resolves our issue.
