### PR TITLE
Add hash length to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ From @garthk, on a 2GHz core you can roughly expect:
 
 The characters that comprise the resultant hash are `./ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789$`.
 
+Resultant hashes will be 60 characters long.
+
 ## Testing
 
 If you create a pull request, tests better pass :)


### PR DESCRIPTION
This information is useful for people creating schemas which store bcrypt hashes. According to [this StackOverflow question](http://stackoverflow.com/questions/5881169/what-column-type-length-should-i-use-for-storing-a-bcrypt-hashed-password-in-a-d) hashes can also be 59 characters long but every hash I've generated with this library starts with `$2a$` so I assume it's safe to assume 60 characters.
