### PR TITLE
travis: use `npm test` only. `npm install` attempts to download prebu…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ sudo: false
 before_install:
   - $CXX --version
   - if [ "$TRAVIS_NODE_VERSION" = "0.8" ]; then npm install -g npm@2.7.3; fi;
+
+install: true
+
+script: npm test


### PR DESCRIPTION
 `npm install` attempts to download prebuilt node-pre-gyp binary:
https://travis-ci.org/ksmyth/node.bcrypt.js/jobs/165239737#L279

Use `npm test` instead, which will build the binary.