### PR TITLE
add optional parameter 'seed' to genSalt() and genSaltSync() to use a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ If you are using bcrypt on a simple script, using the sync mode is perfectly fin
 
   * `genSaltSync(rounds, seed)`
     * `rounds` - [OPTIONAL] - number of rounds, the cost of processing the data. (default - 10)
-    * `seed` - [OPTIONAL] - 16-byte buffer with random seed (default - crypto.randomBytes(16))
+    * `saltbase` - [OPTIONAL] - 16-byte Buffer with unencoded salt as base (default - `crypto.randomBytes(16)`)
   * `genSalt(rounds, seed, cb)`
     * `rounds` - [OPTIONAL] - number of rounds, the cost of processing the data. (default - 10)
-    * `seed` - [OPTIONAL] - 16-byte buffer with random seed (default - crypto.randomBytes(16))
+    * `saltbase` - [OPTIONAL] - 16-byte Buffer with unencoded salt as base (default - `crypto.randomBytes(16)`)
     * `cb` - [REQUIRED] - a callback to be fired once the salt has been generated. uses eio making it asynchronous.
       * `err` - First parameter to the callback detailing any errors.
       * `salt` - Second parameter to the callback providing the generated salt.
@@ -235,7 +235,7 @@ The code for this comes from a few sources:
 * [Nate Rajlich][tootallnate] - Bindings and build process.
 * [Sean McArthur][seanmonstar] - Windows Support
 * [Fanie Oosthuysen][weareu] - Windows Support
-* [Tino Lange][coldcoff] - seed support for genSalt, genSaltSync
+* [Tino Lange][coldcoff] - saltbase support for genSalt, genSaltSync
 
 ## License
 Unless stated elsewhere, file headers or otherwise, the license as stated in the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -147,10 +147,12 @@ If you are using bcrypt on a simple script, using the sync mode is perfectly fin
 
 `BCrypt.`
 
-  * `genSaltSync(rounds)`
-    * `rounds` - [OPTIONAL] - the cost of processing the data. (default - 10)
-  * `genSalt(rounds, cb)`
-    * `rounds` - [OPTIONAL] - the cost of processing the data. (default - 10)
+  * `genSaltSync(rounds, seed)`
+    * `rounds` - [OPTIONAL] - number of rounds, the cost of processing the data. (default - 10)
+    * `seed` - [OPTIONAL] - 16-byte buffer with random seed (default - crypto.randomBytes(16))
+  * `genSalt(rounds, seed, cb)`
+    * `rounds` - [OPTIONAL] - number of rounds, the cost of processing the data. (default - 10)
+    * `seed` - [OPTIONAL] - 16-byte buffer with random seed (default - crypto.randomBytes(16))
     * `cb` - [REQUIRED] - a callback to be fired once the salt has been generated. uses eio making it asynchronous.
       * `err` - First parameter to the callback detailing any errors.
       * `salt` - Second parameter to the callback providing the generated salt.
@@ -233,6 +235,7 @@ The code for this comes from a few sources:
 * [Nate Rajlich][tootallnate] - Bindings and build process.
 * [Sean McArthur][seanmonstar] - Windows Support
 * [Fanie Oosthuysen][weareu] - Windows Support
+* [Tino Lange][coldcoff] - seed support for genSalt, genSaltSync
 
 ## License
 Unless stated elsewhere, file headers or otherwise, the license as stated in the LICENSE file.

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -9,31 +9,43 @@ var crypto = require('crypto');
 
 /// generate a salt (sync)
 /// @param {Number} [rounds] number of rounds (default 10)
+/// @param {Buffer} [seed] random seed (default crypto.randomBytes(16))
 /// @return {String} salt
-module.exports.genSaltSync = function(rounds) {
+module.exports.genSaltSync = function(rounds, seed) {
     // default 10 rounds
     if (!rounds) {
         rounds = 10;
     } else if (typeof rounds !== 'number') {
         throw new Error('rounds must be a number');
     }
-
-    return bindings.gen_salt_sync(rounds, crypto.randomBytes(16));
+    // seed default is random data
+    if (!seed) {
+	seed = crypto.randomBytes(16);
+    } else if (!Buffer.isBuffer(seed) || seed.length != 16) {
+        throw new Error('seed must be a 16 byte Buffer');
+    }
+    return bindings.gen_salt_sync(rounds, seed);
 };
 
 /// generate a salt
 /// @param {Number} [rounds] number of rounds (default 10)
+/// @param {Buffer} [seed] random seed (default crypto.randomBytes(16))
 /// @param {Function} cb callback(err, salt)
-module.exports.genSalt = function(rounds, ignore, cb) {
+module.exports.genSalt = function(rounds, seed, cb) {
     // if callback is first argument, then use defaults for others
     if (typeof arguments[0] === 'function') {
         // have to set callback first otherwise arguments are overriden
         cb = arguments[0];
-        rounds = 10;
+        rounds = undefined;
     // callback is second argument
     } else if (typeof arguments[1] === 'function') {
         // have to set callback first otherwise arguments are overriden
         cb = arguments[1];
+	seed = undefined;
+    }
+
+    if (!cb) {
+        throw new Error('no callback given');
     }
 
     // default 10 rounds
@@ -46,18 +58,22 @@ module.exports.genSalt = function(rounds, ignore, cb) {
         });
     }
 
-    if (!cb) {
-        return;
+    if (!seed) {
+	crypto.randomBytes(16, function(error, randomBytes) {
+            if (error) {
+		cb(error);
+		return;
+            }
+            bindings.gen_salt(rounds, randomBytes, cb);
+	});
+    } else if (!Buffer.isBuffer(seed) || seed.length != 16) {
+        // callback error asynchronously
+        return process.nextTick(function() {
+	    cb(new Error('seed must be a 16 byte Buffer'));
+	});
+    } else {
+        bindings.gen_salt(rounds, seed, cb);
     }
-
-    crypto.randomBytes(16, function(error, randomBytes) {
-        if (error) {
-            cb(error);
-            return;
-        }
-
-        bindings.gen_salt(rounds, randomBytes, cb);
-    });
 };
 
 /// hash data using a salt

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -9,9 +9,9 @@ var crypto = require('crypto');
 
 /// generate a salt (sync)
 /// @param {Number} [rounds] number of rounds (default 10)
-/// @param {Buffer} [seed] random seed (default crypto.randomBytes(16))
+/// @param {Buffer} [saltbase] 16-byte Buffer with unencoded salt as base (default crypto.randomBytes(16))
 /// @return {String} salt
-module.exports.genSaltSync = function(rounds, seed) {
+module.exports.genSaltSync = function(rounds, saltbase) {
     // default 10 rounds
     if (!rounds) {
         rounds = 10;
@@ -19,19 +19,19 @@ module.exports.genSaltSync = function(rounds, seed) {
         throw new Error('rounds must be a number');
     }
     // seed default is random data
-    if (!seed) {
-	seed = crypto.randomBytes(16);
-    } else if (!Buffer.isBuffer(seed) || seed.length != 16) {
-        throw new Error('seed must be a 16 byte Buffer');
+    if (!saltbase) {
+        saltbase = crypto.randomBytes(16);
+    } else if (!Buffer.isBuffer(saltbase) || saltbase.length !== 16) {
+        throw new Error('saltbase must be a 16-byte Buffer');
     }
-    return bindings.gen_salt_sync(rounds, seed);
+    return bindings.gen_salt_sync(rounds, saltbase);
 };
 
 /// generate a salt
 /// @param {Number} [rounds] number of rounds (default 10)
-/// @param {Buffer} [seed] random seed (default crypto.randomBytes(16))
+/// @param {Buffer} [saltbase] 16-byte Buffer with unencoded salt as base (default crypto.randomBytes(16))
 /// @param {Function} cb callback(err, salt)
-module.exports.genSalt = function(rounds, seed, cb) {
+module.exports.genSalt = function(rounds, saltbase, cb) {
     // if callback is first argument, then use defaults for others
     if (typeof arguments[0] === 'function') {
         // have to set callback first otherwise arguments are overriden
@@ -41,7 +41,7 @@ module.exports.genSalt = function(rounds, seed, cb) {
     } else if (typeof arguments[1] === 'function') {
         // have to set callback first otherwise arguments are overriden
         cb = arguments[1];
-	seed = undefined;
+        saltbase = undefined;
     }
 
     if (!cb) {
@@ -58,21 +58,21 @@ module.exports.genSalt = function(rounds, seed, cb) {
         });
     }
 
-    if (!seed) {
-	crypto.randomBytes(16, function(error, randomBytes) {
+    if (!saltbase) {
+        crypto.randomBytes(16, function(error, randomBytes) {
             if (error) {
-		cb(error);
-		return;
+                cb(error);
+                return;
             }
             bindings.gen_salt(rounds, randomBytes, cb);
-	});
-    } else if (!Buffer.isBuffer(seed) || seed.length != 16) {
+        });
+    } else if (!Buffer.isBuffer(saltbase) || saltbase.length !== 16) {
         // callback error asynchronously
         return process.nextTick(function() {
-	    cb(new Error('seed must be a 16 byte Buffer'));
-	});
+            cb(new Error('saltbase must be a 16-byte Buffer'));
+        });
     } else {
-        bindings.gen_salt(rounds, seed, cb);
+        bindings.gen_salt(rounds, saltbase, cb);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "Ben Noorduis <> (https://github.com/bnoordhuis)",
     "Nate Rajlich <nathan@tootallnate.net> (https://github.com/tootallnate)",
     "Sean McArthur <sean.monstar@gmail.com> (https://github.com/seanmonstar)",
-    "Fanie Oosthuysen <fanie.oosthuysen@gmail.com> (https://github.com/weareu)"
+    "Fanie Oosthuysen <fanie.oosthuysen@gmail.com> (https://github.com/weareu)",
+    "Tino Lange <Tino.Lange@interactivedata.com> (https://github.com/coldcoff)"
   ],
   "binary": {
     "module_name": "bcrypt_lib",


### PR DESCRIPTION
Hi Nicholas,

Thanks for node.bcrypt.js!

Please find attached a pull request adding an optional parameter 'seed' to genSalt() and genSaltSync() to use a specific seed instead of crypto.randomBytes(16). We need this for one of our applications.

Cheers,

Tino
