### PR TITLE
Automate release uploading from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,11 @@ before_install:
   - echo Building for Node $TRAVIS_NODE_VERSION
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=$LINUX_CXX; $CXX --version; fi;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then c++ --version; fi;
-  - if [[ "$TRAVIS_NODE_VERSION" == "4" || "$TRAVIS_NODE_VERSION" == "5" ]]; then npm install -g npm@5; else npm install -g npm@latest; fi;
+  - if [[ "$TRAVIS_NODE_VERSION" -lt "6" ]]; then npm install -g npm@5; else npm install -g npm@latest; fi;
 
 install: true
 
 script: npm test
 
 after_success:
-  - REGEX='^v(0|[1-9]+)\.(0|[1-9]+)\.(0|[1-9]+)$'
-  - if [[ $TRAVIS_TAG =~ $REGEX ]] || [[ $TRAVIS_COMMIT_MESSAGE == *"publish binary"* ]]; then echo "Publishing"; npm install node-pre-gyp-github; ./node_modules/.bin/node-pre-gyp configure; ./node_modules/.bin/node-pre-gyp build; ./node_modules/.bin/node-pre-gyp package; ./node_modules/.bin/node-pre-gyp-github publish --release; fi;
+  - if [[ $TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then echo "Publishing"; npm install node-pre-gyp-github@1.3.1; ./node_modules/.bin/node-pre-gyp configure; ./node_modules/.bin/node-pre-gyp build; ./node_modules/.bin/node-pre-gyp package; ./node_modules/.bin/node-pre-gyp-github publish --release; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - echo Building for Node $TRAVIS_NODE_VERSION
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=$LINUX_CXX; $CXX --version; fi;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then c++ --version; fi;
-  - if [[ "$TRAVIS_NODE_VERSION" -lt "6" ]]; then npm install -g npm@5; else npm install -g npm@latest; fi;
+  - npm install -g npm@latest
 
 install: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,7 @@ install:
   - where npm
   - where node
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - 'if "%nodejs_version%" LEQ 5 (npm install -g npm@5) else (npm install -g npm@latest)'
-  - 'if "%nodejs_version%_%platform%" == "4_x86" (npm config set -g cafile=package.json && npm config set -g strict-ssl=false)'
+  - 'npm install -g npm@latest'
 
 build: off
 
@@ -40,5 +39,5 @@ test_script:
 
 on_success:
   - .\node_modules\.bin\node-pre-gyp package
-  - ps: if $APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED -like '*publish binary*' { echo "Publishing"; npm install node-pre-gyp-github@1.3.1; ./node_modules/.bin/node-pre-gyp configure; ./node_modules/.bin/node-pre-gyp build; ./node_modules/.bin/node-pre-gyp package; ./node_modules/.bin/node-pre-gyp-github publish --release }
- 
+  - ps: if ($APPVEYOR_REPO_TAG_NAME -match '^v(0|[1-9]+)\.(0|[1-9]+)\.(0|[1-9]+)$') { echo "Publishing"; npm install node-pre-gyp-github@1.3.1; ./node_modules/.bin/node-pre-gyp-github publish --release }
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,5 +38,7 @@ test_script:
   - npm --version
   - npm test
 
-after_test:
+on_success:
   - .\node_modules\.bin\node-pre-gyp package
+  - ps: if $APPVEYOR_REPO_COMMIT_MESSAGE_EXTENDED -like '*publish binary*' { echo "Publishing"; npm install node-pre-gyp-github@1.3.1; ./node_modules/.bin/node-pre-gyp configure; ./node_modules/.bin/node-pre-gyp build; ./node_modules/.bin/node-pre-gyp package; ./node_modules/.bin/node-pre-gyp-github publish --release }
+ 

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "binary": {
     "module_name": "bcrypt_lib",
     "module_path": "./lib/binding/",
-    "host": "https://github.com",
-    "remote_path": "/kelektiv/node.bcrypt.js/releases/download/v{version}/",
-    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{libc}.tar.gz"
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{libc}.tar.gz",
+    "host": "https://github.com/kelektiv/node.bcrypt.js/releases/download/",
+    "remote_path": "v{version}"
   }
 }


### PR DESCRIPTION
PR for #470 

* Currently targets Linux and OSX
* Uses [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github) upload helper in `.travis.yml`
It requires a `NODE_PRE_GYP_GITHUB_TOKEN` env var in travis repository wide config.

To trigger binary publishing, push a tag in format `vX.Y.Z`

Here are some: [test results](https://github.com/Agathver/node.bcrypt.js/releases)