### PR TITLE
Add benchmarking script.

### DIFF
--- a/bcrypt-benchmark.js
+++ b/bcrypt-benchmark.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+var bcrypt = require('./bcrypt');
+
+function range(start, stop, fn) {
+    var i, array = [];
+    for (i = start; i <= stop; i++) {
+        array.push(fn(i));
+    }
+    return array;
+}
+
+function sum(values) {
+    return values.reduce(function (a, b) { return a + b; });
+}
+
+function randomstring(length) {
+    var chars = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    return sum(range(1, length, function () {
+        return chars[Math.floor(Math.random() * chars.length)];
+    }));
+}
+
+function time_compare(rounds) {
+    var password = randomstring(25);
+    var start = process.hrtime();
+    bcrypt.hashSync(password, rounds);
+    var elapsed = process.hrtime(start);
+    return (elapsed[0] * 1e9 + elapsed[1]) / 1e6;
+}
+
+range(10, 16, function (rounds) {
+    process.stdout.write(rounds + ' rounds: ');
+    var values = range(1, 10, function (i) {
+        var time = time_compare(rounds);
+        process.stdout.write(time.toFixed(3));
+        if (i != 10) process.stdout.write(', ');
+        return time;
+    });
+    var avg = sum(values) / values.length;
+    process.stdout.write(' = ' + avg.toFixed(3) + 'ms')
+    process.stdout.write(' ('+(1000/avg).toFixed(2)+' hash/sec)\n');
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "test": "npm install --build-from-source && nodeunit test",
     "install": "node-pre-gyp install --fallback-to-build"
   },
+  "bin": {
+    "bcrypt-benchmark": "./bcrypt-benchmark.js"
+  },
   "dependencies": {
     "nan": "2.6.2",
     "node-pre-gyp": "0.6.36"


### PR DESCRIPTION
Per https://github.com/kelektiv/node.bcrypt.js/issues/249#issuecomment-220818935 from @matthewoates. 

Example output:
```
10 rounds: 83.330, 83.284, 84.292, 83.322, 86.074, 83.564, 84.646, 83.472, 83.392, 83.131 = 83.851ms (11.93 hash/sec)
11 rounds: 166.622, 166.348, 167.359, 168.675, 168.461, 169.661, 166.178, 165.492, 165.720, 167.446 = 167.196ms (5.98 hash/sec)
12 rounds: 338.399, 333.083, 335.630, 335.099, 332.971, 338.685, 336.236, 335.065, 336.575, 337.179 = 335.892ms (2.98 hash/sec)
13 rounds: 690.170, 673.027, 673.721, 665.404, 664.789, 669.385, 669.233, 663.989, 670.213, 670.549 = 671.048ms (1.49 hash/sec)
14 rounds: 1344.496, 1339.139, 1340.979, 1333.595, 1331.732, 1334.206, 1335.919, 1342.665, 1498.700, 1359.854 = 1356.129ms (0.74 hash/sec)
15 rounds: 2681.134, 2735.165, 2678.616, 2680.423, 2671.868, 2674.606, 2707.496, 2697.091, 2674.569, 2674.919 = 2687.589ms (0.37 hash/sec)
16 rounds: 5353.948, 5341.936, 5348.344, 5345.610, 5483.913, 5341.275, 5494.401, 5457.835, 5491.910, 5563.183 = 5422.236ms (0.18 hash/sec)
```