### PR TITLE
Remove support for NodeJS < 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ os:
   - osx
 
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
   - "6"
@@ -29,7 +26,7 @@ before_install:
   - echo Building for Node $TRAVIS_NODE_VERSION
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX=$LINUX_CXX; $CXX --version; fi;
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then c++ --version; fi;
-  - if [[ $(echo "$TRAVIS_NODE_VERSION <= 0.12" | bc -l) ]]; then npm install -g npm@2; else npm install -g npm@latest; fi;
+  - npm install -g npm@latest
 
 install: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,5 @@
 environment:
   matrix:
-  - nodejs_version: "0.10"
-    platform: x64
-  - nodejs_version: "0.10"
-    platform: x86
-  - nodejs_version: "0.12"
-    platform: x64
-  - nodejs_version: "0.12"
-    platform: x86
   - nodejs_version: "4"
     platform: x64
   - nodejs_version: "4"
@@ -33,8 +25,7 @@ install:
   - where npm
   - where node
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - 'if %nodejs_version% lss 4 npm install -g npm@2'
-  - 'if %nodejs_version% geq 4 npm install -g npm@latest'
+  - 'npm install -g npm@latest'
   - 'if "%nodejs_version%_%platform%" == "4_x86" (npm config set -g cafile=package.json && npm config set -g strict-ssl=false)'
 
 build: off

--- a/lib/promises.js
+++ b/lib/promises.js
@@ -7,11 +7,6 @@
 /// @return {Promise} a Promise encapuslaing the function
 module.exports.promise = function (fn, context, args) {
 
-    //can't do anything without Promise so fail silently
-    if (typeof Promise === 'undefined') {
-        return;
-    }
-
     if (!Array.isArray(args)) {
         args = Array.prototype.slice.call(args);
     }
@@ -35,12 +30,5 @@ module.exports.promise = function (fn, context, args) {
 
 /// @param {err} the error to be thrown
 module.exports.reject = function (err) {
-
-    // silently swallow errors if Promise is not defined
-    // emulating old behavior
-    if (typeof Promise === 'undefined') {
-        return;
-    }
-
     return Promise.reject(err);
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "version": "1.0.3",
   "author": "Nick Campbell (https://github.com/ncb000gt)",
   "engines": {
-    "node": ">= 0.6.0"
+    "node": ">= 4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
NodeJS < 4 are way past their LTS cycles. Even npm has left them behind, and supporting them will be increasingly difficult. It makes sense to drop support for these old NodeJS versions.

Closes #529 