### PR TITLE
Update node-pre-gyp to fix security issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "crypto"
   ],
   "main": "./bcrypt",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "author": "Nick Campbell (https://github.com/ncb000gt)",
   "engines": {
-    "node": ">= 4.0.0"
+    "node": ">= 6.0.0"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "nan": "2.10.0",
-    "node-pre-gyp": "0.9.1"
+    "node-pre-gyp": "0.10.0"
   },
   "devDependencies": {
     "nodeunit": "~0.11.1"
@@ -53,7 +53,8 @@
     "Nate Rajlich <nathan@tootallnate.net> (https://github.com/tootallnate)",
     "Sean McArthur <sean.monstar@gmail.com> (https://github.com/seanmonstar)",
     "Fanie Oosthuysen <fanie.oosthuysen@gmail.com> (https://github.com/weareu)",
-    "Amitosh Swain Mahapatra <amitosh.swain@gmail.com> (https://github.com/Agathver)"
+    "Amitosh Swain Mahapatra <amitosh.swain@gmail.com> (https://github.com/Agathver)",
+    "Corbin Crutchley <crutchcorn@gmail.com> (https://github.com/crutchcorn)"
   ],
   "binary": {
     "module_name": "bcrypt_lib",


### PR DESCRIPTION
Because `node-pre-gyp` v`0.9.1` has a dependency that opens security issues, I updated the version to `0.10.0` in order to fix this. I've ran tests and they all passed perfectly fine. That being said, I had to bump the version of Node supported to `6` rather than `4` (as `pre-gyp` drops support for `4` due to EOL upcoming) and thusly updated the major version of the package to `3.0.0` rather than `2.0.2` or `2.1.0` because of how semver works.

Either way, not a massive change.

Fixes #604