### PR TITLE
readme: improve readability of version table

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you are on a stable version of node, we can't magically know what you are doi
 | 0.4            | <= 0.4         |
 | 0.6, 0.8, 0.10 | >= 0.5         |
 | 0.11           | >= 0.8         |
-| 4              | <= 2           |
+| 4              | < 2.1          |
 | 8              | >= 1.0.3       |
 | 10             | >= 3           |
 

--- a/README.md
+++ b/README.md
@@ -16,16 +16,14 @@ If you are on a stable version of node, we can't magically know what you are doi
 
 ## Version Compatibility
 
-| Node Version | Bcrypt Version |
-| ---- | ---- |
-| 0.4.x | <= 0.4.x |
-| 0.6.x | >= 0.5.x |
-| 0.8.x | >= 0.5.x |
-| 0.10.x | >= 0.5.x |
-| 0.11.x | >= 0.8.x |
-| 4.x.x | <= 2.0.x |
-| 8.x.x | >= 1.0.3 |
-| 10.x.x | >= 3.0.0 |
+| Node Version   | Bcrypt Version |
+| -------------- | -------------- |
+| 0.4            | <= 0.4         |
+| 0.6, 0.8, 0.10 | >= 0.5         |
+| 0.11           | >= 0.8         |
+| 4              | <= 2           |
+| 8              | >= 1.0.3       |
+| 10             | >= 3           |
 
 `node-gyp` only works with stable/released versions of node. Since the `bcrypt` module uses `node-gyp` to build and install you'll need a stable version of node to use bcrypt. If you do not you'll likely see an error that starts with:
 


### PR DESCRIPTION
This improves the readability of the version compatibility table by:
* Combining rows so that bcrypt versions are not repeated
* Dropping unnecessary punctuation