### PR TITLE
Allow using an enterprise artifactory.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "module_name": "bcrypt_lib",
     "module_path": "./lib/binding/napi-v{napi_build_version}",
     "package_name": "{module_name}-v{version}-napi-v{napi_build_version}-{platform}-{arch}-{libc}.tar.gz",
-    "host": "https://github.com/kelektiv/node.bcrypt.js/releases/download/",
-    "remote_path": "v{version}",
+    "host": "https://github.com",
+    "remote_path": "kelektiv/node.bcrypt.js/releases/download/v{version}",
     "napi_versions": [
       3
     ]


### PR DESCRIPTION
Revert to using a deep remote path so that the local artifactory can host gyp binaries of different packages.