### PR TITLE
Add z/OS support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,11 @@
             'uint=unsigned int',
           ],
         }],
+        [ 'OS=="zos"', {
+          'cflags': [
+            '-qascii',
+          ],
+        }],
       ],
     },
     {

--- a/src/node_blf.h
+++ b/src/node_blf.h
@@ -49,6 +49,14 @@
 #define u_int64_t unsigned __int64
 #endif
 
+/* z/OS compatibility */
+#ifdef __MVS__
+typedef unsigned char u_int8_t;
+typedef unsigned short u_int16_t;
+typedef unsigned int u_int32_t;
+typedef unsigned long long u_int64_t;
+#endif
+
 #define BCRYPT_VERSION '2'
 #define BCRYPT_MAXSALT 16	/* Precomputation is just so nice */
 #define BCRYPT_BLOCKS 6		/* Ciphertext blocks */


### PR DESCRIPTION
These changes enable building on z/OS systems:

- add typedefs for z/OS compatibility
- add z/OS compile options 