### PR TITLE
Updated the examples to use the word response instead of res to avoid…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Note that both techniques achieve the same end-result.
 
 ```javascript
 // Load hash from your password DB.
-bcrypt.compare(myPlaintextPassword, hash, function(err, response) {
-    // response == true
+bcrypt.compare(myPlaintextPassword, hash, function(err, result) {
+    // result == true
 });
-bcrypt.compare(someOtherPlaintextPassword, hash, function(err, response) {
-    // response == false
+bcrypt.compare(someOtherPlaintextPassword, hash, function(err, result) {
+    // == false
 });
 ```
 
@@ -150,11 +150,11 @@ bcrypt.hash(myPlaintextPassword, saltRounds).then(function(hash) {
 ```
 ```javascript
 // Load hash from your password DB.
-bcrypt.compare(myPlaintextPassword, hash).then(function(response) {
-    // response == true
+bcrypt.compare(myPlaintextPassword, hash).then(function(result) {
+    // result == true
 });
-bcrypt.compare(someOtherPlaintextPassword, hash).then(function(response) {
-    // response == false
+bcrypt.compare(someOtherPlaintextPassword, hash).then(function(result) {
+    // result == false
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Note that both techniques achieve the same end-result.
 
 ```javascript
 // Load hash from your password DB.
-bcrypt.compare(myPlaintextPassword, hash, function(err, res) {
-    // res == true
+bcrypt.compare(myPlaintextPassword, hash, function(err, response) {
+    // response == true
 });
-bcrypt.compare(someOtherPlaintextPassword, hash, function(err, res) {
-    // res == false
+bcrypt.compare(someOtherPlaintextPassword, hash, function(err, response) {
+    // response == false
 });
 ```
 
@@ -150,11 +150,11 @@ bcrypt.hash(myPlaintextPassword, saltRounds).then(function(hash) {
 ```
 ```javascript
 // Load hash from your password DB.
-bcrypt.compare(myPlaintextPassword, hash).then(function(res) {
-    // res == true
+bcrypt.compare(myPlaintextPassword, hash).then(function(response) {
+    // response == true
 });
-bcrypt.compare(someOtherPlaintextPassword, hash).then(function(res) {
-    // res == false
+bcrypt.compare(someOtherPlaintextPassword, hash).then(function(response) {
+    // response == false
 });
 ```
 


### PR DESCRIPTION
Hi,

I love this library and have used it for years and also taught classes with it. 

The most common use case of using Bcrypt is to hash a password inside of a REST API. The convention for many of these libraries is to use res to indicate response. 

I've seen dozens of students bewildered and hours of debugging gone to waste because the parameter res overwrites the existing one and the error message given is not clear about this. 

All of this can simply be avoided by changing the example to call is response instead of res. Please consider this change. 