### PR TITLE
Updated to node-addon-api 2.0.0. Other little optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ const someOtherPlaintextPassword = 'not_bacon';
 Technique 1 (generate a salt and hash on separate function calls):
 
 ```javascript
-var salt = bcrypt.genSaltSync(saltRounds);
-var hash = bcrypt.hashSync(myPlaintextPassword, salt);
+const salt = bcrypt.genSaltSync(saltRounds);
+const hash = bcrypt.hashSync(myPlaintextPassword, salt);
 // Store hash in your password DB.
 ```
 
 Technique 2 (auto-gen a salt and hash):
 
 ```javascript
-var hash = bcrypt.hashSync(myPlaintextPassword, saltRounds);
+const hash = bcrypt.hashSync(myPlaintextPassword, saltRounds);
 // Store hash in your password DB.
 ```
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -25,10 +25,11 @@
           ]
         }],
         ['OS=="mac"', {
+          'cflags+': ['-fvisibility=hidden'],
           "xcode_settings": {
             "CLANG_CXX_LIBRARY": "libc++",
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-            'MACOSX_DEPLOYMENT_TARGET': '10.7'
+            'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
         }]
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1341,9 +1341,9 @@
       "dev": true
     },
     "node-addon-api": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.2.tgz",
-      "integrity": "sha512-479Bjw9nTE5DdBSZZWprFryHGjUaQC31y1wHo19We/k0BZlrmhqQitWoUL0cD8+scljCbIUL+E58oRDEakdGGA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.0.tgz",
+      "integrity": "sha512-ASCL5U13as7HhOExbT6OlWJJUV/lLzL2voOSP1UVehpRD8FbSrSDjfScK/KwAvVTI5AS6r4VwbOMlIqtvRidnA=="
     },
     "node-pre-gyp": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "node-pre-gyp": "0.14.0",
-    "node-addon-api": "^1.6.2"
+    "node-addon-api": "^2.0.0"
   },
   "devDependencies": {
     "nodeunit": "^0.11.3"

--- a/src/bcrypt_node.cc
+++ b/src/bcrypt_node.cc
@@ -145,7 +145,7 @@ namespace {
 
             void Execute() {
                 if (!(ValidateSalt(salt.c_str()))) {
-                     SetError("Invalid salt. Salt must be in the form of: $Vers$log2(NumRounds)$saltvalue");
+                    SetError("Invalid salt. Salt must be in the form of: $Vers$log2(NumRounds)$saltvalue");
                 }
                 char bcrypted[_PASSWORD_LEN];
                 bcrypt(input.c_str(), salt.c_str(), bcrypted);


### PR DESCRIPTION
In this PR I made the following changes:
- On `binding.gyp` I removed `MACOSX_DEPLOYMENT_TARGET': '10.7'` because now the default target for macOS is 10.10.
- On `EncryptAsyncWorker` I used the `SetError` method to dispatch the error from `Execute` to the default `OnError` handler.
- Some fixes on documentation to be consistent with other parts.
- Update to `node-addon-api` version `2.0.0`
