### PR TITLE
Timing safe string compare function

### DIFF
--- a/src/bcrypt_node.cc
+++ b/src/bcrypt_node.cc
@@ -191,7 +191,14 @@ namespace {
 
     /* COMPARATOR */
     inline bool CompareStrings(const char* s1, const char* s2) {
-        return strcmp(s1, s2) == 0;
+        bool ok = true;
+        while (*s1 != '\0') {
+            ok &= (*s1 == *s2);
+            s1 += 1;
+            s2 += (*s2 != '\0');
+        }
+        ok &= (*s1 == '\0') & (*s2 == '\0');
+        return ok;
     }
 
     class CompareAsyncWorker : public Napi::AsyncWorker {


### PR DESCRIPTION
The implementation for [`CompareStrings`](https://github.com/kelektiv/node.bcrypt.js/blob/master/src/bcrypt_node.cc#L193) function initially used [`strcmp`](http://www.cplusplus.com/reference/cstring/strcmp/), which is not timing safe, i.e. it breaks at the first non-equal character which allows information to be extracted about the prefix that is matching. This could allow to guess the number of chars matching or the size of the hash.

To avoid that, we use the modified `CompareStrings`, that will iterate over all the character until the very end of the supplied string only. So, in this way all operations will happen exactly the length of supplied string `s1` times, so no information gets leaked about the number of characters matched and the length of the unknown string `s2`.