### PR TITLE
Add note about dropping node 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 4.0.0 (2020-02-17)
 
   * Switch to NAPI bcrypt
+  * Drop support for NodeJS 8
 
 # 3.0.8 (2019-12-31)
 


### PR DESCRIPTION
Readme is already up-to-date, but might be worth mentioning it in the changelog aswell