### PR TITLE
Build for linux-arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ os:
 - linux
 - osx
 
+arch:
+- amd64
+- arm64
+
 node_js:
 - '10'
 - '11'


### PR DESCRIPTION
Propose to build and publish linux-arm64 binaries with Travis CI's build matrix.

Build and test seemed to work [in my fork](https://travis-ci.org/github/jokester/node.bcrypt.js/builds/691693082), but the `deploy` part is untested.

(I'm neither of a experienced TravisCI / gyp / npm user, if anything is wrong please let me know )