### PR TITLE
Allow optional use of Node Buffers.

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -83,7 +83,7 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 };
 
 /// hash data using a salt
-/// @param {String} data the data to encrypt
+/// @param {String|Buffer} data the data to encrypt
 /// @param {String} salt the salt to use when hashing
 /// @return {String} hash
 module.exports.hashSync = function hashSync(data, salt) {
@@ -91,8 +91,8 @@ module.exports.hashSync = function hashSync(data, salt) {
         throw new Error('data and salt arguments required');
     }
 
-    if (typeof data !== 'string' || (typeof salt !== 'string' && typeof salt !== 'number')) {
-        throw new Error('data must be a string and salt must either be a salt string or a number of rounds');
+    if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
+        throw new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
     }
 
     if (typeof salt === 'number') {
@@ -103,21 +103,21 @@ module.exports.hashSync = function hashSync(data, salt) {
 };
 
 /// hash data using a salt
-/// @param {String} data the data to encrypt
+/// @param {String|Buffer} data the data to encrypt
 /// @param {String} salt the salt to use when hashing
 /// @param {Function} cb callback(err, hash)
 module.exports.hash = function hash(data, salt, cb) {
     var error;
 
     if (typeof data === 'function') {
-        error = new Error('data must be a string and salt must either be a salt string or a number of rounds');
+        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
         return process.nextTick(function() {
             data(error);
         });
     }
 
     if (typeof salt === 'function') {
-        error = new Error('data must be a string and salt must either be a salt string or a number of rounds');
+        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
         return process.nextTick(function() {
             salt(error);
         });
@@ -140,8 +140,8 @@ module.exports.hash = function hash(data, salt, cb) {
         });
     }
 
-    if (typeof data !== 'string' || (typeof salt !== 'string' && typeof salt !== 'number')) {
-        error = new Error('data must be a string and salt must either be a salt string or a number of rounds');
+    if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
+        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
         return process.nextTick(function() {
             cb(error);
         });
@@ -158,7 +158,7 @@ module.exports.hash = function hash(data, salt, cb) {
 };
 
 /// compare raw data to hash
-/// @param {String} data the data to hash and compare
+/// @param {String|Buffer} data the data to hash and compare
 /// @param {String} hash expected hash
 /// @return {bool} true if hashed data matches hash
 module.exports.compareSync = function compareSync(data, hash) {
@@ -166,15 +166,15 @@ module.exports.compareSync = function compareSync(data, hash) {
         throw new Error('data and hash arguments required');
     }
 
-    if (typeof data !== 'string' || typeof hash !== 'string') {
-        throw new Error('data and hash must be strings');
+    if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
+        throw new Error('data must be a string or Buffer and hash must be a string');
     }
 
     return bindings.compare_sync(data, hash);
 };
 
 /// compare raw data to hash
-/// @param {String} data the data to hash and compare
+/// @param {String|Buffer} data the data to hash and compare
 /// @param {String} hash expected hash
 /// @param {Function} cb callback(err, matched) - matched is true if hashed data matches hash
 module.exports.compare = function compare(data, hash, cb) {
@@ -211,7 +211,7 @@ module.exports.compare = function compare(data, hash, cb) {
         });
     }
 
-    if (typeof data !== 'string' || typeof hash !== 'string') {
+    if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
         error = new Error('data and hash must be strings');
         return process.nextTick(function() {
             cb(error);

--- a/test/implementation.js
+++ b/test/implementation.js
@@ -29,6 +29,7 @@ module.exports = {
     test_embedded_nulls: function(assert) {
         assert.strictEqual(bcrypt.hashSync("Passw\0rd123", "$2b$05$CCCCCCCCCCCCCCCCCCCCC."), "$2b$05$CCCCCCCCCCCCCCCCCCCCC.VHy/kzL4sCcX3Ib3wN5rNGiRt.TpfxS");
         assert.strictEqual(bcrypt.hashSync("Passw\0 you can literally write anything after the NUL character", "$2b$05$CCCCCCCCCCCCCCCCCCCCC."), "$2b$05$CCCCCCCCCCCCCCCCCCCCC.4vJLJQ6nZ/70INTjjSZWQ0iyUek92tu");
+        assert.strictEqual(bcrypt.hashSync(Buffer.from("Passw\0 you can literally write anything after the NUL character"), "$2b$05$CCCCCCCCCCCCCCCCCCCCC."), "$2b$05$CCCCCCCCCCCCCCCCCCCCC.4vJLJQ6nZ/70INTjjSZWQ0iyUek92tu");
         assert.done();
     },
     test_shorten_salt_to_128_bits: function(assert) {
@@ -43,6 +44,10 @@ module.exports = {
         assert.strictEqual(bcrypt.hashSync("p@5sw0rd", "$2b$12$zQ4CooEXdGqcwi0PHsgc8e"), "$2b$12$zQ4CooEXdGqcwi0PHsgc8eAf0DLXE/XHoBE8kCSGQ97rXwuClaPam");
         assert.strictEqual(bcrypt.hashSync("C'est bon, la vie!", "$2b$12$cbo7LZ.wxgW4yxAA5Vqlv."), "$2b$12$cbo7LZ.wxgW4yxAA5Vqlv.KR6QFPt4qCdc9RYJNXxa/rbUOp.1sw.");
         assert.strictEqual(bcrypt.hashSync("ἓν οἶδα ὅτι οὐδὲν οἶδα", "$2b$12$LeHKWR2bmrazi/6P22Jpau"), "$2b$12$LeHKWR2bmrazi/6P22JpauX5my/eKwwKpWqL7L5iEByBnxNc76FRW");
-        assert.done();
+        assert.strictEqual(bcrypt.hashSync(Buffer.from("ἓν οἶδα ὅτι οὐδὲν οἶδα"), "$2b$12$LeHKWR2bmrazi/6P22Jpau"), "$2b$12$LeHKWR2bmrazi/6P22JpauX5my/eKwwKpWqL7L5iEByBnxNc76FRW");
+        bcrypt.hash(Buffer.from("ἓν οἶδα ὅτι οὐδὲν οἶδα"), "$2b$12$LeHKWR2bmrazi/6P22Jpau", function(err, hash) {
+            assert.strictEqual(hash, "$2b$12$LeHKWR2bmrazi/6P22JpauX5my/eKwwKpWqL7L5iEByBnxNc76FRW");
+            assert.done();
+        });
     }
 }


### PR DESCRIPTION
The hash(Sync) and compare(Sync) methods will now accept data as a string or Buffer.

Also removed a few extraneous string copy operations.