### PR TITLE
[FEATURE] Hash by max time allotted #787 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ bcrypt.hash(myPlaintextPassword, saltRounds, function(err, hash) {
 
 Note that both techniques achieve the same end-result.
 
+Technique 3 (same as technique 2 but defining work in terms of time (not rounds)):
+
+exptime = maximum time allotted for hashing  [#787](https://github.com/kelektiv/node.bcrypt.js/issues/787)
+```javascript
+bcrypt.hashByTime(myPlaintextPassword, expTime, function(err, hash) {
+    // Store hash in your password DB.
+});
+```
+
 #### To check a password:
 
 ```javascript

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -1,37 +1,35 @@
 'use strict';
-
 var nodePreGyp = require('@mapbox/node-pre-gyp');
 var path = require('path');
 var binding_path = nodePreGyp.find(path.resolve(path.join(__dirname, './package.json')));
 var bindings = require(binding_path);
-
 var crypto = require('crypto');
-
 var promises = require('./promises');
 
 /// generate a salt (sync)
 /// @param {Number} [rounds] number of rounds (default 10)
 /// @return {String} salt
 module.exports.genSaltSync = function genSaltSync(rounds, minor) {
-    // default 10 rounds
-    if (!rounds) {
-        rounds = 18;
-    } else if (typeof rounds !== 'number') {
-        throw new Error('rounds must be a number');
-    }
+  // default 10 rounds
+  if (!rounds) {
+    rounds = 18;
+  } else if (typeof rounds !== 'number') {
+    throw new Error('rounds must be a number');
+  }
 
-    if(!minor) {
-        minor = 'b';
-    } else if(minor !== 'b' && minor !== 'a') {
-        throw new Error('minor must be either "a" or "b"');
-    }
+  if (!minor) {
+    minor = 'b';
+  } else if (minor !== 'b' && minor !== 'a') {
+    throw new Error('minor must be either "a" or "b"');
+  }
 
-    return bindings.gen_salt_sync(minor, rounds, crypto.randomBytes(16));
+  return bindings.gen_salt_sync(minor, rounds, crypto.randomBytes(16));
 };
 
 /// generate a salt
 /// @param {Number} [rounds] number of rounds (default 10)
 /// @param {Function} cb callback(err, salt)
+
 module.exports.genSalt = function genSalt(rounds, minor, cb) {
     var error;
 
@@ -63,23 +61,23 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
         });
     }
 
-    if(!minor) {
-        minor = 'b'
-    } else if(minor !== 'b' && minor !== 'a') {
-        error = new Error('minor must be either "a" or "b"');
-        return process.nextTick(function() {
-            cb(error);
-        });
+    if (!minor) {
+      minor = 'b'
+    } else if (minor !== 'b' && minor !== 'a') {
+      error = new Error('minor must be either "a" or "b"');
+      return process.nextTick(function() {
+        cb(error);
+      });
     }
 
     crypto.randomBytes(16, function(error, randomBytes) {
-        if (error) {
-            cb(error);
-            return;
-        }
+      if (error) {
+        cb(error);
+        return;
+      }
 
-        bindings.gen_salt(minor, rounds, randomBytes, cb);
-    });
+    bindings.gen_salt(minor, rounds, randomBytes, cb);
+  });
 };
 
 /// hash data using a salt
@@ -87,19 +85,19 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 /// @param {String} salt the salt to use when hashing
 /// @return {String} hash
 module.exports.hashSync = function hashSync(data, salt) {
-    if (data == null || salt == null) {
-        throw new Error('data and salt arguments required');
-    }
+  if (data == null || salt == null) {
+    throw new Error('data and salt arguments required');
+  }
 
-    if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
-        throw new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
-    }
+  if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
+    throw new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+  }
 
-    if (typeof salt === 'number') {
-        salt = module.exports.genSaltSync(salt);
-    }
+  if (typeof salt === 'number') {
+    salt = module.exports.genSaltSync(salt);
+  }
 
-    return bindings.encrypt_sync(data, salt);
+  return bindings.encrypt_sync(data, salt);
 };
 
 /// hash data using a salt
@@ -107,54 +105,167 @@ module.exports.hashSync = function hashSync(data, salt) {
 /// @param {String} salt the salt to use when hashing
 /// @param {Function} cb callback(err, hash)
 module.exports.hash = function hash(data, salt, cb) {
-    var error;
+  var error;
 
-    if (typeof data === 'function') {
-        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
-        return process.nextTick(function() {
-            data(error);
-        });
+  if (typeof data === 'function') {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      data(error);
+    });
+  }
+
+  if (typeof salt === 'function') {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      salt(error);
+    });
+  }
+
+  // cb exists but is not a function
+  // return a rejecting promise
+  if (cb && typeof cb !== 'function') {
+    return promises.reject(new Error('cb must be a function or null to return a Promise'));
+  }
+
+  if (!cb) {
+    return promises.promise(hash, this, [data, salt]);
+  }
+
+  if (data == null || salt == null) {
+    error = new Error('data and salt arguments required');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
+
+  if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
+
+
+  if (typeof salt === 'number') {
+    return module.exports.genSalt(salt, function(err, salt) {
+      return bindings.encrypt(data, salt, cb);
+    });
+  }
+
+  return bindings.encrypt(data, salt, cb);
+};
+
+//For getting salts with the help of expected time, not rounds
+
+module.exports.genSaltByTime = function genSaltByTime(exptime, minor, cb) {
+  var error;
+  var rounds = 10;
+  // if callback is first argument, then use defaults for others
+  if (typeof arguments[0] === 'function') {
+    // have to set callback first otherwise arguments are overriden
+    cb = arguments[0];
+    exptime = 100;
+    minor = 'b';
+    // callback is second argument
+  } else if (typeof arguments[1] === 'function') {
+    // have to set callback first otherwise arguments are overriden
+    cb = arguments[1];
+    minor = 'b';
+  }
+
+  if (!cb) {
+    return promises.promise(genSalt, this, [rounds, minor]);
+  }
+
+  // default 100 miliseconds and minimum 4 miliseconds
+  if (!exptime) {
+    exptime = 100;
+  } else if (exptime < 4) {
+    exptime = 4;
+  } else if (typeof exptime !== 'number') {
+    // callback error asynchronously
+    error = new Error('Expected time must be a number');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
+
+  if (!minor) {
+    minor = 'b'
+  } else if (minor !== 'b' && minor !== 'a') {
+    error = new Error('minor must be either "a" or "b"');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
+
+  crypto.randomBytes(16, function(error, randomBytes) {
+    if (error) {
+      cb(error);
+      return;
     }
 
-    if (typeof salt === 'function') {
-        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
-        return process.nextTick(function() {
-            salt(error);
-        });
-    }
+    //since the relation b/w expected time and rounds roughly follows exptime = 2^(rounds-3)
+    //rounds is equal to log2(exptime)+3
+    rounds = Math.log(exptime)/Math.log(2);
+    rounds = Math.round(rounds)+3;
 
-    // cb exists but is not a function
-    // return a rejecting promise
-    if (cb && typeof cb !== 'function') {
-        return promises.reject(new Error('cb must be a function or null to return a Promise'));
-    }
+    // for a secure hash, taking 4 as minimum rounds
+    rounds = Math.max(rounds, 4);
+    bindings.gen_salt(minor, rounds, randomBytes, cb);
 
-    if (!cb) {
-        return promises.promise(hash, this, [data, salt]);
-    }
+  });
+};
 
-    if (data == null || salt == null) {
-        error = new Error('data and salt arguments required');
-        return process.nextTick(function() {
-            cb(error);
-        });
-    }
+module.exports.hashByTime = function hashByTime(data, salt, cb) {
+  var error;
 
-    if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
-        error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
-        return process.nextTick(function() {
-            cb(error);
-        });
-    }
+  if (typeof data === 'function') {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      data(error);
+    });
+  }
+
+  if (typeof salt === 'function') {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      salt(error);
+    });
+  }
+
+  // cb exists but is not a function
+  // return a rejecting promise
+  if (cb && typeof cb !== 'function') {
+    return promises.reject(new Error('cb must be a function or null to return a Promise'));
+  }
+
+  if (!cb) {
+    return promises.promise(hash, this, [data, salt]);
+  }
+
+  if (data == null || salt == null) {
+    error = new Error('data and salt arguments required');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
+
+  if (!(typeof data === 'string' || data instanceof Buffer) || (typeof salt !== 'string' && typeof salt !== 'number')) {
+    error = new Error('data must be a string or Buffer and salt must either be a salt string or a number of rounds');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
 
 
-    if (typeof salt === 'number') {
-        return module.exports.genSalt(salt, function(err, salt) {
-            return bindings.encrypt(data, salt, cb);
-        });
-    }
+  if (typeof salt === 'number') {
+    return module.exports.genSaltByTime(salt, function(err, salt) {
+      return bindings.encrypt(data, salt, cb);
+    });
+  }
 
-    return bindings.encrypt(data, salt, cb);
+  return bindings.encrypt(data, salt, cb);
 };
 
 /// compare raw data to hash
@@ -162,15 +273,15 @@ module.exports.hash = function hash(data, salt, cb) {
 /// @param {String} hash expected hash
 /// @return {bool} true if hashed data matches hash
 module.exports.compareSync = function compareSync(data, hash) {
-    if (data == null || hash == null) {
-        throw new Error('data and hash arguments required');
-    }
+  if (data == null || hash == null) {
+    throw new Error('data and hash arguments required');
+  }
 
-    if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
-        throw new Error('data must be a string or Buffer and hash must be a string');
-    }
+  if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
+    throw new Error('data must be a string or Buffer and hash must be a string');
+  }
 
-    return bindings.compare_sync(data, hash);
+  return bindings.compare_sync(data, hash);
 };
 
 /// compare raw data to hash
@@ -178,59 +289,59 @@ module.exports.compareSync = function compareSync(data, hash) {
 /// @param {String} hash expected hash
 /// @param {Function} cb callback(err, matched) - matched is true if hashed data matches hash
 module.exports.compare = function compare(data, hash, cb) {
-    var error;
+  var error;
 
-    if (typeof data === 'function') {
-        error = new Error('data and hash arguments required');
-        return process.nextTick(function() {
-            data(error);
-        });
-    }
+  if (typeof data === 'function') {
+    error = new Error('data and hash arguments required');
+    return process.nextTick(function() {
+      data(error);
+    });
+  }
 
-    if (typeof hash === 'function') {
-        error = new Error('data and hash arguments required');
-        return process.nextTick(function() {
-            hash(error);
-        });
-    }
+  if (typeof hash === 'function') {
+    error = new Error('data and hash arguments required');
+    return process.nextTick(function() {
+      hash(error);
+    });
+  }
 
-    // cb exists but is not a function
-    // return a rejecting promise
-    if (cb && typeof cb !== 'function') {
-        return promises.reject(new Error('cb must be a function or null to return a Promise'));
-    }
+  // cb exists but is not a function
+  // return a rejecting promise
+  if (cb && typeof cb !== 'function') {
+    return promises.reject(new Error('cb must be a function or null to return a Promise'));
+  }
 
-    if (!cb) {
-        return promises.promise(compare, this, [data, hash]);
-    }
+  if (!cb) {
+    return promises.promise(compare, this, [data, hash]);
+  }
 
-    if (data == null || hash == null) {
-        error = new Error('data and hash arguments required');
-        return process.nextTick(function() {
-            cb(error);
-        });
-    }
+  if (data == null || hash == null) {
+    error = new Error('data and hash arguments required');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
 
-    if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
-        error = new Error('data and hash must be strings');
-        return process.nextTick(function() {
-            cb(error);
-        });
-    }
+  if (!(typeof data === 'string' || data instanceof Buffer) || typeof hash !== 'string') {
+    error = new Error('data and hash must be strings');
+    return process.nextTick(function() {
+      cb(error);
+    });
+  }
 
-    return bindings.compare(data, hash, cb);
+  return bindings.compare(data, hash, cb);
 };
 
 /// @param {String} hash extract rounds from this hash
 /// @return {Number} the number of rounds used to encrypt a given hash
 module.exports.getRounds = function getRounds(hash) {
-    if (hash == null) {
-        throw new Error('hash argument required');
-    }
+  if (hash == null) {
+    throw new Error('hash argument required');
+  }
 
-    if (typeof hash !== 'string') {
-        throw new Error('hash must be a string');
-    }
+  if (typeof hash !== 'string') {
+    throw new Error('hash must be a string');
+  }
 
-    return bindings.get_rounds(hash);
+  return bindings.get_rounds(hash);
 };

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -15,7 +15,7 @@ var promises = require('./promises');
 module.exports.genSaltSync = function genSaltSync(rounds, minor) {
     // default 10 rounds
     if (!rounds) {
-        rounds = 10;
+        rounds = 18;
     } else if (typeof rounds !== 'number') {
         throw new Error('rounds must be a number');
     }


### PR DESCRIPTION
Feature implementation for defining work in terms of time and not rounds is done. The required task is performed by observing the graph between number of rounds and time taken.  It is observed that the relationship almost follows below formula:
```
number_of_rounds = log2(expected_time) + 3
```
The files changed are readme.md and bcrypt.js
``` javascript
bcrypt.hashByTime(myPlaintextPassword, expTime, function(err, hash) {
     // Store hash in your password DB.
});
```
``` javascript
genSaltByTime(...){
    .
    .
    .
    //since the relation b/w expected time and rounds roughly follows exptime = 2^(rounds-3)
    //rounds is equal to log2(expTime)+3
    rounds = Math.log(expTime)/Math.log(2);
    rounds = Math.round(rounds)+3;
    // for a secure hash, taking 4 as minimum rounds
    rounds = Math.max(rounds, 4);
    bindings.gen_salt(minor, rounds, randomBytes, cb)
}
```