### PR TITLE
fix: update travis CI Docker image repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ script:
 - |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]
   then
+    docker image pull public.ecr.aws/docker/library/node:${TRAVIS_NODE_VERSION}-alpine
     docker run -w /src --entrypoint /bin/sh -v`pwd`:/src "node:${TRAVIS_NODE_VERSION}-alpine" test_alpine.sh
   fi
 


### PR DESCRIPTION
based on issue #929 
--- 
Hello.

When I checked the Travis CI now, I checked the case where it was failed due to DockerHub's Image Pull Rate Limit.

I suggest using awsecr public gallery where official nodejs image is provided.

If this is used, it is not restricted by Rate Limit, and the test can be carried out using the same image as the official Docker image.

