### PR TITLE
chore(appveyor): not use latest npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ install:
   - where npm
   - where node
   - ps: Install-Product node $env:nodejs_version $env:platform
-  - 'npm install -g npm@latest'
 
 build: off
 


### PR DESCRIPTION
This changes appveyor from using the latest npm version to only using the preinstalled npm version. 
it's guaranteed to be a compatible version.