### PR TITLE
Fixed z/OS build issue

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -87,10 +87,14 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 /// @param {String} salt the salt to use when hashing
 /// @return {String} hash
 module.exports.hashSync = function hashSync(data, salt) {
+
     if (data == null || salt == null) {
         throw new Error('data and salt arguments required');
     }
-
+    
+    if (salt === '') {
+	throw new Error('Salt cannot be empty');
+    }
     if (typeof data !== 'string' || (typeof salt !== 'string' && typeof salt !== 'number')) {
         throw new Error('data must be a string and salt must either be a salt string or a number of rounds');
     }

--- a/bcrypt.js
+++ b/bcrypt.js
@@ -87,14 +87,10 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 /// @param {String} salt the salt to use when hashing
 /// @return {String} hash
 module.exports.hashSync = function hashSync(data, salt) {
-
     if (data == null || salt == null) {
         throw new Error('data and salt arguments required');
     }
-    
-    if (salt === '') {
-	throw new Error('Salt cannot be empty');
-    }
+
     if (typeof data !== 'string' || (typeof salt !== 'string' && typeof salt !== 'number')) {
         throw new Error('data must be a string and salt must either be a salt string or a number of rounds');
     }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables": {
+    "NODE_VERSION%":"<!(node -p \"process.versions.node.split(\\\".\\\")[0]\")"
+  },
   'targets': [
     {
       'target_name': 'bcrypt_lib',
@@ -34,6 +37,11 @@
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
+        }],
+        ['OS=="zos" and NODE_VERSION < 16',{
+            'cflags': [
+              '-qascii',
+            ],
         }],
       ],
     },

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,10 +38,11 @@
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
         }],
-        ['OS=="zos" and NODE_VERSION < 16',{
+        ['OS=="zos" and NODE_VERSION < 17',{
             'cflags': [
               '-qascii',
             ],
+            "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
         }],
       ],
     },

--- a/binding.gyp
+++ b/binding.gyp
@@ -35,11 +35,6 @@
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
         }],
-        [ 'OS=="zos"', {
-          'cflags': [
-            '-qascii',
-          ],
-        }],
       ],
     },
     {

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,11 +38,10 @@
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
         }],
-        ['OS=="zos" and NODE_VERSION < 17',{
+        ['OS=="zos" and NODE_VERSION < 16',{
             'cflags': [
               '-qascii',
             ],
-            "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
         }],
       ],
     },

--- a/binding.gyp
+++ b/binding.gyp
@@ -38,10 +38,11 @@
             'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES', # -fvisibility=hidden
           }
         }],
-        ['OS=="zos" and NODE_VERSION < 16',{
+        ['OS=="zos" and NODE_VERSION <= 16',{
             'cflags': [
               '-qascii',
             ],
+            'defines': ["NAPI_DISABLE_CPP_EXCEPTIONS"],
         }],
       ],
     },


### PR DESCRIPTION
Removed the njsc -q flags from bindings.gyp for Node versions <= 16

For Node.js v18 and above, native addons will be built using clang instead of njsc/njsc++ 