### PR TITLE
Include platform, arch, and libc in module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "binary": {
     "module_name": "bcrypt_lib",
-    "module_path": "./lib/binding/napi-v{napi_build_version}",
+    "module_path": "./lib/binding/napi-v{napi_build_version}-{platform}-{arch}-{libc}",
     "package_name": "{module_name}-v{version}-napi-v{napi_build_version}-{platform}-{arch}-{libc}.tar.gz",
     "host": "https://github.com",
     "remote_path": "kelektiv/node.bcrypt.js/releases/download/v{version}",


### PR DESCRIPTION
Makes it possible to have binaries for multiple platforms installed at once. Fixes #1001

<img width="443" alt="darwin and linux binaries both installed" src="https://github.com/kelektiv/node.bcrypt.js/assets/7433263/2f957fc8-471a-4dc3-b049-7ebe054a9a89">
