### PR TITLE
fix:typo error in comments in bcrypt.js file

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -35,13 +35,13 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 
     // if callback is first argument, then use defaults for others
     if (typeof arguments[0] === 'function') {
-        // have to set callback first otherwise arguments are overriden
+        // have to set callback first otherwise arguments are overridden
         cb = arguments[0];
         rounds = 10;
         minor = 'b';
     // callback is second argument
     } else if (typeof arguments[1] === 'function') {
-        // have to set callback first otherwise arguments are overriden
+        // have to set callback first otherwise arguments are overridden
         cb = arguments[1];
         minor = 'b';
     }


### PR DESCRIPTION
##What does this PR do?
This PR fixes the typo error of "overriden" to "overridden" in comments of bcrypt.js

Fixes #1033
![Screenshot 2024-05-07 224314](https://github.com/kelektiv/node.bcrypt.js/assets/108021303/1c90515f-4f3b-47b7-9469-50c6d48124b7)

##Type of Change
-Typo fix