### PR TITLE
fix/typo-overridden-word

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -35,13 +35,13 @@ module.exports.genSalt = function genSalt(rounds, minor, cb) {
 
     // if callback is first argument, then use defaults for others
     if (typeof arguments[0] === 'function') {
-        // have to set callback first otherwise arguments are overriden
+        // have to set callback first otherwise arguments are overridden
         cb = arguments[0];
         rounds = 10;
         minor = 'b';
     // callback is second argument
     } else if (typeof arguments[1] === 'function') {
-        // have to set callback first otherwise arguments are overriden
+        // have to set callback first otherwise arguments are overridden
         cb = arguments[1];
         minor = 'b';
     }


### PR DESCRIPTION
##What does this PR do?
This PR fixes the typo error of "overriden" to "overridden" in comments of bcrypt.js

Fixes : #1033

![image](https://github.com/kelektiv/node.bcrypt.js/assets/155576040/a574767d-f2ad-4665-aec3-02d027b5bd73)

#Type of Change
-Typo fix