### PR TITLE
Fix redefine variable in async_compare.js

### DIFF
--- a/examples/async_compare.js
+++ b/examples/async_compare.js
@@ -20,8 +20,8 @@ var bcrypt = require('../bcrypt');
     console.log('compared true cb end: ' + (Date.now() - start) + 'ms');
 
     // compare
-    const res = await bcrypt.compare('bacon', crypted)
-    console.log('compared false: ' + res);
+    const res2 = await bcrypt.compare('bacon', crypted)
+    console.log('compared false: ' + res2);
     console.log('compared false cb end: ' + (Date.now() - start) + 'ms');
 
     console.log('end: ' + (Date.now() - start) + 'ms');


### PR DESCRIPTION
This was giving a syntax error because res was defined twice. I just renamed the second one so it should be valid JS now.