### PR TITLE
chore: fix typos in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@
   * Fix for issue around empty string params throwing Errors.
   * Method deprecation.
   * Upgrade from libeio/ev to libuv. (shtylman)
-  ** --- NOTE --- Breaks 0.4.x compatability
+  ** --- NOTE --- Breaks 0.4.x compatibility
   * EV_MULTIPLICITY compile flag.
 
 # v0.4.1

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ _Pre-built binaries for various NodeJS versions are made available on a best-eff
 
 Only the current stable and supported LTS releases (Node 18+) are actively tested against.
 
-_There may be an interval between the release of the module and the availabilty of the compiled modules._
+_There may be an interval between the release of the module and the availability of the compiled modules._
 
 Currently, we have pre-built binaries that support the following platforms:
 


### PR DESCRIPTION
fix typos in docs