### PR TITLE
Exclude test files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .lock*
 build*/
 *.sw[a-z]
+test


### PR DESCRIPTION
## Summary

Adds `test` to the existing `.npmignore` to exclude the `test/` directory from the published npm package.

The test files (~36KB) are shipped to npm but serve no purpose for consumers.

## Changes

- Added `test` to `.npmignore`