### PR TITLE
ci: add Node 24 and 25 to test matrices, Node 24 to build matrix

### DIFF
--- a/.github/workflows/build-pack-publish.yml
+++ b/.github/workflows/build-pack-publish.yml
@@ -95,7 +95,7 @@ jobs:
     needs: pack
     strategy:
       matrix:
-        node-version: [ 18, 20, 22, 23 ]
+        node-version: [ 18, 20, 22, 24, 25 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [18, 20, 22, 24]
     container:
       image: node:${{ matrix.node-version }}-alpine
     steps:


### PR DESCRIPTION
## CI updates

### `ci.yaml`
- Add Node 24 to `build` and `build-alpine` jobs

### `build-pack-publish.yaml` (`test-package` job)
- Add Node 24 (Active LTS)
- Add Node 25 (Current)
- Drop Node 23