### PR TITLE
fix: reject negative salt rounds in hash()

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -14,6 +14,8 @@ function genSaltSync(rounds, minor) {
         rounds = 10;
     } else if (typeof rounds !== 'number') {
         throw new Error('rounds must be a number');
+    } else if (rounds < 0) {
+        throw new Error('rounds must be a positive number');
     }
 
     if (!minor) {
@@ -54,6 +56,12 @@ function genSalt(rounds, minor, cb) {
     } else if (typeof rounds !== 'number') {
         // callback error asynchronously
         error = new Error('rounds must be a number');
+        return process.nextTick(function () {
+            cb(error);
+        });
+    } else if (rounds < 0) {
+        // callback error asynchronously
+        error = new Error('rounds must be a positive number');
         return process.nextTick(function () {
             cb(error);
         });
@@ -146,6 +154,9 @@ function hash(data, salt, cb) {
 
     if (typeof salt === 'number') {
         return module.exports.genSalt(salt, function (err, salt) {
+            if (err) {
+                return cb(err);
+            }
             return bindings.encrypt(data, salt, cb);
         });
     }

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -34,6 +34,15 @@ test('salt_rounds_is_string_non_number', done => {
     });
 })
 
+test('salt_rounds_is_negative', done => {
+    expect.assertions(2);
+    bcrypt.genSalt(-5, function (err, salt) {
+        expect(err instanceof Error).toBe(true)
+        expect(err.message).toBe('rounds must be a positive number')
+        done();
+    });
+})
+
 test('salt_minor', done => {
     expect.assertions(3);
     bcrypt.genSalt(10, 'a', function (err, value) {
@@ -71,6 +80,15 @@ test('hash_rounds', done => {
     expect.assertions(1);
     bcrypt.hash('bacon', 8, function (err, hash) {
         expect(bcrypt.getRounds(hash)).toEqual(8);
+        done();
+    });
+})
+
+test('hash_rounds_is_negative', done => {
+    expect.assertions(2);
+    bcrypt.hash('bacon', -5, function (err, hash) {
+        expect(err instanceof Error).toBe(true);
+        expect(err.message).toBe('rounds must be a positive number');
         done();
     });
 })

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -23,6 +23,14 @@ test('salt_rounds_is_string_non_number', () => {
     return expect(bcrypt.genSalt('b')).rejects.toThrow('rounds must be a number');
 })
 
+test('salt_rounds_is_negative', () => {
+    return expect(bcrypt.genSalt(-5)).rejects.toThrow('rounds must be a positive number');
+})
+
+test('hash_rounds_is_negative', () => {
+    return expect(bcrypt.hash('password', -5)).rejects.toThrow('rounds must be a positive number');
+})
+
 test('hash_returns_promise_on_null_callback', () => {
     expect(typeof bcrypt.hash('password', 10, null).then).toStrictEqual('function')
 })

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -23,6 +23,10 @@ test('salt_rounds_is_NaN', () => {
     expect(() => bcrypt.genSaltSync('b')).toThrowError("rounds must be a number");
 })
 
+test('salt_rounds_is_negative', () => {
+    expect(() => bcrypt.genSaltSync(-5)).toThrowError("rounds must be a positive number");
+})
+
 test('salt_minor_a', () => {
     const salt = bcrypt.genSaltSync(10, 'a');
     const [_, version, rounds] = salt.split('$');
@@ -44,6 +48,10 @@ test('hash', () => {
 test('hash_rounds', () => {
     const hash = bcrypt.hashSync('password', 8);
     expect(bcrypt.getRounds(hash)).toStrictEqual(8)
+})
+
+test('hash_rounds_is_negative', () => {
+    expect(() => bcrypt.hashSync('password', -5)).toThrowError('rounds must be a positive number');
 })
 
 test('hash_empty_string', () => {


### PR DESCRIPTION
## Summary
- Add validation to reject negative salt rounds with a clear error message
- Fix error propagation from `genSalt` to `hash()` callback
- Add test coverage for negative rounds across sync, async, and promise APIs

## Problem
Passing a negative value for salt rounds (e.g., `bcrypt.hash('password', -5, cb)`) causes the library to hang indefinitely. This happens because:

1. Negative values pass JavaScript's type validation
2. In the native C++ code, the negative value is cast to `u_int8_t`, causing integer underflow (e.g., `-5` becomes `251`)
3. This results in `1 << 251` rounds, an astronomically large iteration count that causes the hang

## Solution
Add early validation in the JavaScript layer to reject negative rounds with a clear error message "rounds must be a positive number", matching the existing pattern for type validation.

Also fixes a related issue where `genSalt` errors were not properly propagated through the `hash()` callback when salt rounds were invalid.

## Test plan
- [x] Added `salt_rounds_is_negative` test for sync API
- [x] Added `salt_rounds_is_negative` test for async API  
- [x] Added `salt_rounds_is_negative` test for promise API
- [x] Added `hash_rounds_is_negative` test for sync/async/promise APIs
- [x] All 81 tests pass
- [x] Verified manually that negative rounds now throw instead of hanging

Fixes #1218