### PR TITLE
fix: validate salt rounds to prevent hang on negative values

### DIFF
--- a/bcrypt.js
+++ b/bcrypt.js
@@ -14,6 +14,8 @@ function genSaltSync(rounds, minor) {
         rounds = 10;
     } else if (typeof rounds !== 'number') {
         throw new Error('rounds must be a number');
+    } else if (rounds < 0) {
+        throw new Error('rounds must be a positive integer');
     }
 
     if (!minor) {
@@ -54,6 +56,12 @@ function genSalt(rounds, minor, cb) {
     } else if (typeof rounds !== 'number') {
         // callback error asynchronously
         error = new Error('rounds must be a number');
+        return process.nextTick(function () {
+            cb(error);
+        });
+    } else if (rounds < 0) {
+        // callback error asynchronously
+        error = new Error('rounds must be a positive integer');
         return process.nextTick(function () {
             cb(error);
         });
@@ -145,8 +153,11 @@ function hash(data, salt, cb) {
 
 
     if (typeof salt === 'number') {
-        return module.exports.genSalt(salt, function (err, salt) {
-            return bindings.encrypt(data, salt, cb);
+        return module.exports.genSalt(salt, function (err, generatedSalt) {
+            if (err) {
+                return cb(err);
+            }
+            return bindings.encrypt(data, generatedSalt, cb);
         });
     }
 

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -207,3 +207,21 @@ test('hash_compare_one_param', done => {
         done();
     });
 })
+
+test('salt_rounds_is_negative', done => {
+    expect.assertions(2);
+    bcrypt.genSalt(-1, function (err, salt) {
+        expect(err instanceof Error).toBe(true)
+        expect(err.message).toBe('rounds must be a positive integer')
+        done();
+    });
+})
+
+test('hash_rounds_is_negative', done => {
+    expect.assertions(2);
+    bcrypt.hash('password', -1, function (err, hash) {
+        expect(err instanceof Error).toBe(true)
+        expect(err.message).toBe('rounds must be a positive integer')
+        done();
+    });
+})

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -23,6 +23,10 @@ test('salt_rounds_is_string_non_number', () => {
     return expect(bcrypt.genSalt('b')).rejects.toThrow('rounds must be a number');
 })
 
+test('salt_rounds_is_negative', () => {
+    return expect(bcrypt.genSalt(-1)).rejects.toThrow('rounds must be a positive integer');
+})
+
 test('hash_returns_promise_on_null_callback', () => {
     expect(typeof bcrypt.hash('password', 10, null).then).toStrictEqual('function')
 })
@@ -55,6 +59,10 @@ test('hash_no_params', () => {
 
 test('hash_one_param', () => {
     return expect(bcrypt.hash('password')).rejects.toThrow('data and salt arguments required');
+})
+
+test('hash_rounds_is_negative', () => {
+    return expect(bcrypt.hash('password', -1)).rejects.toThrow('rounds must be a positive integer');
 })
 
 test('hash_salt_validity', () => {

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -123,3 +123,11 @@ test('getRounds', () => {
     expect(9).toStrictEqual(bcrypt.getRounds(hash))
     expect(() => bcrypt.getRounds('')).toThrow("invalid hash provided");
 });
+
+test('salt_rounds_is_negative', () => {
+    expect(() => bcrypt.genSaltSync(-1)).toThrowError('rounds must be a positive integer');
+})
+
+test('hash_rounds_is_negative', () => {
+    expect(() => bcrypt.hashSync('password', -1)).toThrowError('rounds must be a positive integer');
+})


### PR DESCRIPTION
## Summary
- Add input validation to reject negative salt rounds with clear error message
- Fix error propagation bug where genSalt errors in hash() were silently ignored
- Add tests for negative rounds validation (sync, async, and promise APIs)

## Problem
Calling `bcrypt.hash('password', -1, callback)` caused the process to hang indefinitely (issue #1218).

**Root cause:** Negative rounds values were passed to the C++ layer, which clamped them to 31 (the maximum valid value). This resulted in 2^31 = 2,147,483,648 iterations - effectively infinite computation time.

## Solution
Validate that rounds must be non-negative in both `genSalt()` and `genSaltSync()`. The error is thrown/returned consistently across all APIs:
- Sync: throws `Error('rounds must be a positive integer')`
- Async callback: passes error to callback
- Promise: rejects with the error

Also fixed a pre-existing bug where errors from `genSalt()` inside `hash()` were not propagated to the callback - the callback was called with `undefined` salt, causing a TypeError.

## Test Plan
- [x] Added `salt_rounds_is_negative` test in sync.test.js
- [x] Added `hash_rounds_is_negative` test in sync.test.js  
- [x] Added `salt_rounds_is_negative` test in async.test.js
- [x] Added `hash_rounds_is_negative` test in async.test.js
- [x] Added `salt_rounds_is_negative` test in promise.test.js
- [x] Added `hash_rounds_is_negative` test in promise.test.js
- [x] All existing tests pass (81 total)

Fixes #1218